### PR TITLE
Moved @types & typescript to Dev Deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,16 +17,18 @@
   },
   "homepage": "https://github.com/zyrouge/fuzzle#readme",
   "dependencies": {
-    "@types/fs-extra": "^9.0.11",
-    "@types/lodash": "^4.14.170",
-    "@types/node": "^15.12.1",
     "cross-env": "^7.0.3",
     "discord-api-types": "^0.18.1",
     "fs-extra": "^10.0.0",
     "got": "^11.8.2",
     "lodash": "^4.17.21",
     "rss-parser": "^3.12.0",
-    "ts-node": "^10.0.0",
-    "typescript": "^4.3.2"
+    "ts-node": "^10.0.0"
+  },
+  "devDependencies": {
+      "@types/fs-extra": "^9.0.11",
+      "@types/lodash": "^4.14.170",
+      "@types/node": "^15.12.1",
+      "typescript": "^4.3.2"
   }
 }


### PR DESCRIPTION
Use types as dev deps since they are not required after compilation and during production.